### PR TITLE
Updated purchase tickets link

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ title: JavaScript Conference in Denver, Colorado on June 24, 2016
 <h2>Tickets on Sale</h2>
 
 <p>
-  We're currently releasing tickets in small batches. You can view the <a href="http://ti.to/dinosaurjs.org">available tickets here</a>. Don't see what you're looking for? A batch might be sold out. We'll be announcing more tickets on our email list and <a href="http://twitter.com/dinosaur_js">on Twitter</a>.
+  We're currently releasing tickets in small batches. You can view the <a href="https://ti.to/dinosaurjs/2016">available tickets here</a>. Don't see what you're looking for? A batch might be sold out. We'll be announcing more tickets on our email list and <a href="http://twitter.com/dinosaur_js">on Twitter</a>.
 </p>
 
 <h2>What is Dinosaur.js?</h2>


### PR DESCRIPTION
Changed link from https://ti.to/dinosaurjs.org on the front page to https://ti.to/dinosaurjs/2016
